### PR TITLE
Fix sbt build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,15 @@
 /bin/
 target/
 .classpath
+
+# bloop and metals
+.bloop
+.bsp
+.metals
+
+# sbt
+project/
+build/
+
+# general
+*.class

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ parallelExecution in Test := false
 
 testOptions in Test += Tests.Argument("-oDF")
 
-EclipseKeys.withSource := true
+// EclipseKeys.withSource := true
 
 libraryDependencies ++= Seq(
   "org.eclipse.birt.runtime" % "org.eclipse.core.resources" % "3.9.0.v20140514-1307",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")


### PR DESCRIPTION
A couple of fixes so that running `sbt compile` doesn't error.

* Comment out "EclipseKeys" in build.sbt, seems IDE specific.
* Update .gitignore
* Remove /project/ folder (this may need to be edited later)