### PR TITLE
Change groupId for org.eclipse.jdt.core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "org.eclipse.core" % "runtime" % "3.10.0-v20140318-2214",
   "org.eclipse.equinox" % "common" % "3.6.200-v20130402-1505",
   "org.eclipse.equinox" % "preferences" % "3.5.200-v20140224-1527",
-  "org.eclipse.tycho" % "org.eclipse.jdt.core" % "3.10.0.v20140604-1726",
+  "org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.10.0",
   "com.github.scala-incubator.io" % "scala-io-file_2.11" % "0.4.3-1",
   "org.scalatest" % "scalatest_2.11" % "2.2.1" % Test
 )


### PR DESCRIPTION
The "org.eclipse.tycho" group didn't seem to include the "org.eclipse.text.edits" package as it would result in sbt displaying a warning about using stub classes. This change results in the warning disappearing.

(Didn't pick up on this in #1 since I started receiving errors about base Java classes not being found)